### PR TITLE
Replaced Microsoft.AspVersioning.Mvc with Asp.Versioning

### DIFF
--- a/CityInfo.API/CityInfo.API.csproj
+++ b/CityInfo.API/CityInfo.API.csproj
@@ -9,11 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Asp.Versioning.Mvc" Version="6.4.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="6.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
     <PackageReference Include="microsoft.entityframeworkcore" Version="6.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.0">

--- a/CityInfo.API/Controllers/CitiesController.cs
+++ b/CityInfo.API/Controllers/CitiesController.cs
@@ -4,6 +4,7 @@ using CityInfo.API.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Text.Json;
+using Asp.Versioning;
 
 namespace CityInfo.API.Controllers
 {

--- a/CityInfo.API/Controllers/PointsOfInterestController.cs
+++ b/CityInfo.API/Controllers/PointsOfInterestController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.JsonPatch;
 using Microsoft.AspNetCore.Mvc;
+using Asp.Versioning;
 
 namespace CityInfo.API.Controllers
 {

--- a/CityInfo.API/Program.cs
+++ b/CityInfo.API/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.OpenApi.Models;
 using Serilog;
 using System.Reflection;
 using System.Text;
+using Asp.Versioning;
 
 Log.Logger = new LoggerConfiguration()  // This is Serilog.Log
     .MinimumLevel.Debug()
@@ -106,7 +107,8 @@ builder.Services.AddAuthorization(options =>
 builder.Services.AddApiVersioning(setupAction =>
 {
     setupAction.AssumeDefaultVersionWhenUnspecified = true;
-    setupAction.DefaultApiVersion = new Microsoft.AspNetCore.Mvc.ApiVersion(1, 0);
+    //setupAction.DefaultApiVersion = new Microsoft.AspNetCore.Mvc.ApiVersion(1, 0);
+    setupAction.DefaultApiVersion = new ApiVersion(1, 0);
     setupAction.ReportApiVersions = true;
 });
 


### PR DESCRIPTION
The other was deprecated

I was able to replace the Microsoft.Versioning.Mvc package, which now has some vulnerabilities, with Asp.Versioning.

Note, however, that another Microsoft package has a problem. I tried upgrading it, twice, without success. So, I left it in..